### PR TITLE
Clone original message when sending messages

### DIFF
--- a/ramp-thermostat/ramp-thermostat.js
+++ b/ramp-thermostat/ramp-thermostat.js
@@ -45,9 +45,9 @@ module.exports = function(RED) {
 
     this.on('input', function(msg) {
       
-      var msg1 = {"topic":"state"};
-      var msg2 = {"topic":"current"};
-      var msg3 = {"topic":"target"};
+      var msg1 = Object.assign(RED.util.cloneMessage(msg), {"topic":"state"});
+      var msg2 = Object.assign(RED.util.cloneMessage(msg), {"topic":"current"});
+      var msg3 = Object.assign(RED.util.cloneMessage(msg), {"topic":"target"});
       
       var result = {};
       


### PR DESCRIPTION
This is a small enhancement where original incoming message is cloned before the 3 thermostat outgoing messages (state, current, target) are sent, keeping the original message context intact.

The reasoning behind this enhancement is: I'm using several instances of the thermostat node in my heating flow and have to differentiate between the target temperatures and heating requests for each of my rooms.